### PR TITLE
Changes to address issues 5, 8, 9 and 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,16 @@ owi2plex --help
 Usage: owi2plex [OPTIONS]
 
 Options:
-  -b, --bouquet TEXT      The name of the bouquet to parse. If not specified
-                          parse all bouquets.
-  -u, --username TEXT     OpenWebIf Username
-  -p, --password TEXT     OpenWebIf Password
-  -h, --host TEXT         OpenWebIf Host
-  -P, --port INTEGER      OpenWebIf Port
-  -o, --output-file TEXT  Output file
-  -l, --list-bouquets     Display a list of bouquets.
-  --help                  Show this message and exit.
+  -b, --bouquet              TEXT     The name of the bouquet to parse. If not specified
+                                      parse all bouquets.
+  -u, --username             TEXT     OpenWebIf username.
+  -p, --password             TEXT     OpenWebIf password.
+  -h, --host                 TEXT     OpenWebIf host.
+  -P, --port                 INTEGER  OpenWebIf port.
+  -o, --output-file          TEXT     Output file.
+  -c, --continuous-numbering BOOLEAN  Continuous numbering across bouquets.
+  -l, --list-bouquets                 Display a list of bouquets.
+  --help                              Show this message and exit.
 ```
 
 ## Examples


### PR DESCRIPTION
This pull request closes #5, closes #8, closes #9 and closes #10.

- Added argument -c or --continuous-numbering for continuous numbering across bouquets
- Added replacement of control characters in `def unescape`
- Changed use of unsorted to sorted dictionaries for services in `def getBouquets` and `def getBouquetsServices`
- Changed version number to 0.1-alpha-5
- Fixed the use of inconsistent capital letters in the help text
- Fixed double UTF-8 encoding of debug_message in `def getEPGs`